### PR TITLE
fix `Tw2.posthoc.tests` to permute within strata

### DIFF
--- a/Wd.R
+++ b/Wd.R
@@ -107,7 +107,7 @@ Tw2.posthoc.tests = function(dm, f, nrep=999, strata=NULL){
     subs = f %in% include.levels
     c(include.levels, 
       table(f[subs, drop=T]), 
-      Tw2.test(dd[subs, subs], f[subs,drop=T], nrep=nrep, strata=strata))
+      Tw2.test(dd[subs, subs], f[subs,drop=T], nrep=nrep, strata=strata[subs]))
   }
   res = t(combn(levels(f), 2, Tw2.subset.test))
   colnames(res) = c("Level1", "Level2", "N1", "N2", "p.value", "tw2.stat", "nrep")


### PR DESCRIPTION
subset `strata` when performing `Tw2.test()` on a subset